### PR TITLE
VPN DNS

### DIFF
--- a/ansible/com.artary.vpnconnect.plist
+++ b/ansible/com.artary.vpnconnect.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.artary.vpnconnect</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/dev-env/bin/vpn-dns</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+  </dict>
+</plist>

--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -7,11 +7,12 @@
 
   tasks:
 
-    # - name: Check Sudo Password
-    #   command: ls
-    #   become: yes
-    #   become_method: sudo
-    #   changed_when: false
+    - name: Check Sudo Password
+      command: ls
+      become: yes
+      become_method: sudo
+      become_flags: -H -S -n -k
+      changed_when: false
 
     - name: Verify Parallels is installed
       shell: test -n "$(mdfind 'kMDItemCFBundleIdentifier == com.parallels.desktop.console')"
@@ -92,3 +93,15 @@
         content: ''
         dest: ~/.irb_history
         force: no
+
+    - name: Start services at login
+      copy: src={{ dev_env_dir }}/ansible/{{ item }}.plist dest=/Library/LaunchDaemons/{{ item }}.plist owner=root group=wheel
+      become: yes
+      with_items: 
+        - com.artary.vpnconnect
+
+    - name: Setup launch agents for services
+      command: launchctl load -w /Library/LaunchAgents/{{ item }}.plist
+      become: yes
+      with_items:
+        - com.artary.vpnconnect

--- a/bin/dev
+++ b/bin/dev
@@ -116,7 +116,7 @@ HEREDOC
 
   def update(args)
     system('cd /usr/local/dev-env && git fetch && git reset --hard origin/master') unless args.first == '--no-pull'
-    exec("ansible-playbook #{root_dir}/ansible/mac.yml -i 127.0.0.1,") if mac?
+    exec("ansible-playbook #{root_dir}/ansible/mac.yml -i 127.0.0.1, -K") if mac?
     exec("ansible-playbook #{root_dir}/ansible/linux.yml -i 127.0.0.1, -K -v") if linux?
   end
 

--- a/bin/vpn-dns
+++ b/bin/vpn-dns
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+echo "Monitoring for VPN DNS changes"
+
+while true; do
+  output=$(scutil << EOF
+list "State:.*VPN"
+exit
+EOF
+  )
+
+  if [[ $output =~ State:/Network/Service/(.+)/VPN ]]; then
+    uuid=${BASH_REMATCH[1]}
+
+    echo "Found ${uuid}"
+
+    output=$(scutil << EOF
+show State:/Network/Service/${uuid}/IPv4
+exit
+EOF
+  )
+
+    echo $output | egrep -o 'Addresses : <array> { [^{]*?10\.80\.81\.\d+[^{]*? }' > /dev/null
+    if [[ $? = "0" ]]; then
+      echo "Detected VPN on 10.80.81.0/24"
+
+      scutil << EOF
+get State:/Network/Service/${uuid}/DNS
+d.add SupplementalMatchDomains * amazonaws.com ec2.internal
+set State:/Network/Service/${uuid}/DNS
+exit
+EOF
+    fi
+  fi
+
+  sleep 2
+done
+echo "Exiting"


### PR DESCRIPTION
The macOS wireguard app doesn't have support for hooks (like PostUp) so I had to do this instead.

This adds split dns to the tunnel.